### PR TITLE
Set release to public by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
   public:
     type: boolean
     description: Whether these artifacts are public or not
-    default: false
+    default: true 
   token:
     description: "Authorized Github Personal Acess Token. Defaults to GITHUB_TOKEN"
     default: ${{ github.token }}


### PR DESCRIPTION
The overwhelming majority of 3p packages are public. Let's set the default accordingly.