### PR TITLE
Added space before `creds=github`

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -50,7 +50,7 @@ function downloadUrl(config: Config, asset: models.ReleaseAsset): string {
 }
 
 function downloadCreds(config: Config, asset: models.ReleaseAsset): string {
-  return config.public_release ? "" : "creds=github"
+  return config.public_release ? "" : " creds=github"
 }
 
 export function generateNotes(config: Config, uploads: models.UploadResult[]): string {


### PR DESCRIPTION
To avoid results like this: https://github.com/secondlife/llphysicsextensions_source/releases/tag/v1.0.c178d39

Turned out there was a space before, so I just brought it back.